### PR TITLE
[FIX] ParseError: 'type' in self._defaults.

### DIFF
--- a/openerp/addons/base/res/ir_property.py
+++ b/openerp/addons/base/res/ir_property.py
@@ -75,7 +75,7 @@ class ir_property(osv.osv):
                 prop = self.browse(cr, uid, ids[0])
                 type_ = prop.type
             else:
-                type_ = self._defaults['type']
+                type_ = self._defaults['type'] if 'type' in self._defaults else 'many2one'
 
         field = TYPE2FIELD.get(type_)
         if not field:


### PR DESCRIPTION
* It happens when installing product, when it's loading product_data.xml for instance, it tries to read the ir.property record and fails because there is no 'type' in self._defaults. There should be cause it's declared.